### PR TITLE
Support for routing cross-origin OPTIONS requests

### DIFF
--- a/spring-cloud-gateway-core/src/test/java/org/springframework/cloud/gateway/test/HttpBinCompatibleController.java
+++ b/spring-cloud-gateway-core/src/test/java/org/springframework/cloud/gateway/test/HttpBinCompatibleController.java
@@ -26,6 +26,7 @@ import java.util.Map;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.springframework.web.bind.annotation.GetMapping;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
@@ -70,19 +71,21 @@ public class HttpBinCompatibleController {
 		return get(exchange);
 	}
 
+	@GetMapping
+	@RequestMapping(path = "/options", produces = MediaType.APPLICATION_JSON_VALUE, method = RequestMethod.OPTIONS)
+	public Map<String, Object> options(ServerWebExchange exchange) {
+		if (log.isDebugEnabled()) {
+			log.debug("httpbin /options");
+		}
+		return buildMapOfArgsAndHeaders(exchange);
+	}
+
 	@RequestMapping(path = "/get", produces = MediaType.APPLICATION_JSON_VALUE)
 	public Map<String, Object> get(ServerWebExchange exchange) {
 		if (log.isDebugEnabled()) {
 			log.debug("httpbin /get");
 		}
-        HashMap<String, Object> result = new HashMap<>();
-        HashMap<String, String> params = new HashMap<>();
-        exchange.getRequest().getQueryParams().forEach((name, values) -> {
-            params.put(name, values.get(0));
-        });
-        result.put("args", params);
-        result.put("headers", getHeaders(exchange));
-        return result;
+        return buildMapOfArgsAndHeaders(exchange);
 	}
 
 	@RequestMapping(value = "/post", consumes = MediaType.MULTIPART_FORM_DATA_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
@@ -131,5 +134,16 @@ public class HttpBinCompatibleController {
 
 	public Map<String, String> getHeaders(ServerWebExchange exchange) {
 		return exchange.getRequest().getHeaders().toSingleValueMap();
+	}
+
+	private Map<String, Object> buildMapOfArgsAndHeaders(ServerWebExchange exchange) {
+		HashMap<String, Object> result = new HashMap<>();
+		HashMap<String, String> params = new HashMap<>();
+		exchange.getRequest().getQueryParams().forEach((name, values) -> {
+			params.put(name, values.get(0));
+		});
+		result.put("args", params);
+		result.put("headers", getHeaders(exchange));
+		return result;
 	}
 }

--- a/spring-cloud-gateway-sample/src/test/java/org/springframework/cloud/gateway/sample/GatewaySampleApplicationTests.java
+++ b/spring-cloud-gateway-sample/src/test/java/org/springframework/cloud/gateway/sample/GatewaySampleApplicationTests.java
@@ -167,6 +167,21 @@ public class GatewaySampleApplicationTests {
 	}
 
 	@Test
+	public void forwardCrossOriginOptionsRequestWorks() {
+		webClient.options()
+				.uri("/options")
+				.header("Host", "www.forwardurl.org")
+				.header("Origin", "www.differentorigin.org") // comment this line to make the test pass
+				.header("Access-Control-Request-Method", "POST")
+				.exchange()
+				.expectStatus()
+				.isOk()
+				.expectBody(String.class)
+				.consumeWith(result ->
+						assertThat(result.getResponseBody()).contains("Access-Control-Request-Method"));
+	}
+
+	@Test
 	public void complexPredicate() {
 		webClient.get()
 				.uri("/anything/png")


### PR DESCRIPTION
It seems that it's currently not possible to route cross-origin OPTIONS requests with Spring Cloud Gateway to other backend services. This would be desirable so that the components serving the requests can decide on their own which CORS headers to return to their clients.

 - [x] Add failing test to `GatewaySampleApplication` documenting what this pull request tries to achieve.
 - [ ] Come up with a solution to make the test pass. I already did some experimenting. See https://github.com/spring-cloud/spring-cloud-gateway/issues/229#issuecomment-462458456.